### PR TITLE
Implement @keyward/platform-web: Keyward class + IndexedDBBackend

### DIFF
--- a/packages/platform-web/package.json
+++ b/packages/platform-web/package.json
@@ -30,6 +30,7 @@
     "idb": "^8.0.0"
   },
   "devDependencies": {
+    "fake-indexeddb": "^6.2.5",
     "tsup": "^8.5.0",
     "typescript": "^6.0.0",
     "vitest": "^4.1.0"

--- a/packages/platform-web/src/IndexedDBBackend.test.ts
+++ b/packages/platform-web/src/IndexedDBBackend.test.ts
@@ -1,0 +1,85 @@
+import 'fake-indexeddb/auto';
+import { IndexedDBBackend } from './IndexedDBBackend.js';
+
+describe('IndexedDBBackend (fake-indexeddb)', () => {
+  let backend: IndexedDBBackend;
+
+  beforeEach(async () => {
+    backend = new IndexedDBBackend();
+    await backend.clear();
+  });
+
+  describe('get / set', () => {
+    it('returns null for a missing key', async () => {
+      expect(await backend.get('missing')).toBeNull();
+    });
+
+    it('stores and retrieves a value', async () => {
+      await backend.set('foo', 'bar');
+      expect(await backend.get('foo')).toBe('bar');
+    });
+
+    it('overwrites an existing value', async () => {
+      await backend.set('foo', 'bar');
+      await backend.set('foo', 'baz');
+      expect(await backend.get('foo')).toBe('baz');
+    });
+
+    it('handles empty string key', async () => {
+      await backend.set('', 'empty');
+      expect(await backend.get('')).toBe('empty');
+    });
+
+    it('handles empty string value', async () => {
+      await backend.set('key', '');
+      expect(await backend.get('key')).toBe('');
+    });
+  });
+
+  describe('remove', () => {
+    it('removes an existing key', async () => {
+      await backend.set('foo', 'bar');
+      await backend.remove('foo');
+      expect(await backend.get('foo')).toBeNull();
+    });
+
+    it('does not throw when removing a non-existent key', async () => {
+      await expect(backend.remove('nope')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('keys', () => {
+    it('returns an empty array when store is empty', async () => {
+      expect(await backend.keys()).toEqual([]);
+    });
+
+    it('returns all stored keys', async () => {
+      await backend.set('a', '1');
+      await backend.set('b', '2');
+      await backend.set('c', '3');
+      const result = await backend.keys();
+      expect(result.sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('does not include removed keys', async () => {
+      await backend.set('a', '1');
+      await backend.set('b', '2');
+      await backend.remove('a');
+      expect(await backend.keys()).toEqual(['b']);
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all keys', async () => {
+      await backend.set('a', '1');
+      await backend.set('b', '2');
+      await backend.clear();
+      expect(await backend.keys()).toEqual([]);
+      expect(await backend.get('a')).toBeNull();
+    });
+
+    it('is a no-op on empty store', async () => {
+      await expect(backend.clear()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/platform-web/src/IndexedDBBackend.ts
+++ b/packages/platform-web/src/IndexedDBBackend.ts
@@ -1,0 +1,52 @@
+import type { KeywardBackend } from '@keyward/core';
+import { openDB } from 'idb';
+
+const DB_NAME = 'keyward';
+const STORE_NAME = 'kv';
+const DB_VERSION = 1;
+
+export class IndexedDBBackend implements KeywardBackend {
+  private dbPromise: ReturnType<typeof openDB> | null = null;
+
+  private getDb(): ReturnType<typeof openDB> {
+    if (!this.dbPromise) {
+      this.dbPromise = openDB(DB_NAME, DB_VERSION, {
+        upgrade(db) {
+          if (!db.objectStoreNames.contains(STORE_NAME)) {
+            db.createObjectStore(STORE_NAME);
+          }
+        },
+      });
+      this.dbPromise.catch(() => {
+        this.dbPromise = null;
+      });
+    }
+    return this.dbPromise;
+  }
+
+  async get(resolvedKey: string): Promise<string | null> {
+    const db = await this.getDb();
+    const value = await db.get(STORE_NAME, resolvedKey);
+    return (value as string | undefined) ?? null;
+  }
+
+  async set(resolvedKey: string, value: string): Promise<void> {
+    const db = await this.getDb();
+    await db.put(STORE_NAME, value, resolvedKey);
+  }
+
+  async remove(resolvedKey: string): Promise<void> {
+    const db = await this.getDb();
+    await db.delete(STORE_NAME, resolvedKey);
+  }
+
+  async keys(): Promise<string[]> {
+    const db = await this.getDb();
+    return db.getAllKeys(STORE_NAME) as Promise<string[]>;
+  }
+
+  async clear(): Promise<void> {
+    const db = await this.getDb();
+    await db.clear(STORE_NAME);
+  }
+}

--- a/packages/platform-web/src/Keyward.test.ts
+++ b/packages/platform-web/src/Keyward.test.ts
@@ -1,0 +1,157 @@
+import type { KeywardBackend, StorageKeyDef } from '@keyward/core';
+import { Scope } from '@keyward/core';
+import { Keyward } from './Keyward.js';
+
+const keyDef = (key: string, scope: Scope): StorageKeyDef => ({ key, scope });
+
+function createMemoryBackend(): KeywardBackend {
+  const store = new Map<string, string>();
+  return {
+    async get(key) {
+      return store.get(key) ?? null;
+    },
+    async set(key, value) {
+      store.set(key, value);
+    },
+    async remove(key) {
+      store.delete(key);
+    },
+    async keys() {
+      return [...store.keys()];
+    },
+    async clear() {
+      store.clear();
+    },
+  };
+}
+
+describe('Keyward', () => {
+  let kw: Keyward;
+
+  beforeEach(() => {
+    kw = new Keyward(createMemoryBackend());
+  });
+
+  describe('userId management', () => {
+    it('returns null initially', () => {
+      expect(kw.getUserId()).toBeNull();
+    });
+
+    it('stores userId after setUserId()', () => {
+      kw.setUserId('alice');
+      expect(kw.getUserId()).toBe('alice');
+    });
+
+    it('resets userId after clearUserId()', () => {
+      kw.setUserId('alice');
+      kw.clearUserId();
+      expect(kw.getUserId()).toBeNull();
+    });
+  });
+
+  describe('get / set / remove', () => {
+    it('returns null for a missing key', async () => {
+      expect(await kw.get(keyDef('app-version', Scope.Global))).toBeNull();
+    });
+
+    it('stores and retrieves a Global-scoped value', async () => {
+      await kw.set(keyDef('app-version', Scope.Global), '1.0');
+      expect(await kw.get(keyDef('app-version', Scope.Global))).toBe('1.0');
+    });
+
+    it('stores and retrieves a Device-scoped value', async () => {
+      await kw.set(keyDef('volume', Scope.Device), '80');
+      expect(await kw.get(keyDef('volume', Scope.Device))).toBe('80');
+    });
+
+    it('stores and retrieves a User-scoped value', async () => {
+      kw.setUserId('alice');
+      await kw.set(keyDef('theme', Scope.User), 'dark');
+      expect(await kw.get(keyDef('theme', Scope.User))).toBe('dark');
+    });
+
+    it('throws when accessing User-scoped key without userId', async () => {
+      await expect(kw.get(keyDef('theme', Scope.User))).rejects.toThrow('Keyward: userId not set.');
+    });
+
+    it('removes a value', async () => {
+      await kw.set(keyDef('app-version', Scope.Global), '1.0');
+      await kw.remove(keyDef('app-version', Scope.Global));
+      expect(await kw.get(keyDef('app-version', Scope.Global))).toBeNull();
+    });
+
+    it('removing a non-existent key does not throw', async () => {
+      await expect(kw.remove(keyDef('nope', Scope.Global))).resolves.toBeUndefined();
+    });
+
+    it('overwrites an existing value', async () => {
+      await kw.set(keyDef('lang', Scope.Global), 'en');
+      await kw.set(keyDef('lang', Scope.Global), 'tr');
+      expect(await kw.get(keyDef('lang', Scope.Global))).toBe('tr');
+    });
+  });
+
+  describe('user isolation', () => {
+    it('different users have separate values for the same key', async () => {
+      kw.setUserId('alice');
+      await kw.set(keyDef('theme', Scope.User), 'dark');
+      kw.setUserId('bob');
+      await kw.set(keyDef('theme', Scope.User), 'light');
+
+      kw.setUserId('alice');
+      expect(await kw.get(keyDef('theme', Scope.User))).toBe('dark');
+      kw.setUserId('bob');
+      expect(await kw.get(keyDef('theme', Scope.User))).toBe('light');
+    });
+
+    it('User-scoped keys do not collide with Device-scoped keys', async () => {
+      kw.setUserId('alice');
+      await kw.set(keyDef('volume', Scope.User), '50');
+      await kw.set(keyDef('volume', Scope.Device), '80');
+
+      expect(await kw.get(keyDef('volume', Scope.User))).toBe('50');
+      expect(await kw.get(keyDef('volume', Scope.Device))).toBe('80');
+    });
+  });
+
+  describe('wipeUser()', () => {
+    it('removes all keys for the given user', async () => {
+      kw.setUserId('alice');
+      await kw.set(keyDef('theme', Scope.User), 'dark');
+      await kw.set(keyDef('lang', Scope.User), 'tr');
+
+      await kw.wipeUser('alice');
+
+      expect(await kw.get(keyDef('theme', Scope.User))).toBeNull();
+      expect(await kw.get(keyDef('lang', Scope.User))).toBeNull();
+    });
+
+    it('does not remove other users keys', async () => {
+      kw.setUserId('alice');
+      await kw.set(keyDef('theme', Scope.User), 'dark');
+      kw.setUserId('bob');
+      await kw.set(keyDef('theme', Scope.User), 'light');
+
+      await kw.wipeUser('alice');
+
+      kw.setUserId('bob');
+      expect(await kw.get(keyDef('theme', Scope.User))).toBe('light');
+    });
+
+    it('does not remove Device or Global keys', async () => {
+      kw.setUserId('alice');
+      await kw.set(keyDef('theme', Scope.User), 'dark');
+      await kw.set(keyDef('volume', Scope.Device), '80');
+      await kw.set(keyDef('app-version', Scope.Global), '1.0');
+
+      await kw.wipeUser('alice');
+
+      expect(await kw.get(keyDef('volume', Scope.Device))).toBe('80');
+      expect(await kw.get(keyDef('app-version', Scope.Global))).toBe('1.0');
+    });
+
+    it('is a no-op for a user with no keys', async () => {
+      await expect(kw.wipeUser('nobody')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/platform-web/src/Keyward.ts
+++ b/packages/platform-web/src/Keyward.ts
@@ -1,0 +1,46 @@
+import type { KeywardBackend, StorageKeyDef } from '@keyward/core';
+import { KeyRegistry } from '@keyward/core';
+
+export class Keyward {
+  private readonly registry: KeyRegistry;
+  private readonly backend: KeywardBackend;
+
+  constructor(backend: KeywardBackend) {
+    this.registry = new KeyRegistry();
+    this.backend = backend;
+  }
+
+  setUserId(userId: string): void {
+    this.registry.setUserId(userId);
+  }
+
+  clearUserId(): void {
+    this.registry.clearUserId();
+  }
+
+  getUserId(): string | null {
+    return this.registry.getUserId();
+  }
+
+  async get(keyDef: StorageKeyDef): Promise<string | null> {
+    const resolved = this.registry.resolve(keyDef);
+    return this.backend.get(resolved);
+  }
+
+  async set(keyDef: StorageKeyDef, value: string): Promise<void> {
+    const resolved = this.registry.resolve(keyDef);
+    await this.backend.set(resolved, value);
+  }
+
+  async remove(keyDef: StorageKeyDef): Promise<void> {
+    const resolved = this.registry.resolve(keyDef);
+    await this.backend.remove(resolved);
+  }
+
+  async wipeUser(userId: string): Promise<void> {
+    const prefix = this.registry.getUserPrefix(userId);
+    const allKeys = await this.backend.keys();
+    const userKeys = allKeys.filter((k) => k.startsWith(prefix));
+    await Promise.all(userKeys.map((key) => this.backend.remove(key)));
+  }
+}

--- a/packages/platform-web/src/index.ts
+++ b/packages/platform-web/src/index.ts
@@ -1,2 +1,4 @@
-export { Scope, KeyRegistry } from '@keyward/core';
-export type { StorageKeyDef, KeywardBackend } from '@keyward/core';
+export type { KeywardBackend, StorageKeyDef } from '@keyward/core';
+export { KeyRegistry, Scope } from '@keyward/core';
+export { IndexedDBBackend } from './IndexedDBBackend.js';
+export { Keyward } from './Keyward.js';

--- a/packages/platform-web/src/vitest-env.d.ts
+++ b/packages/platform-web/src/vitest-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vitest/globals" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,6 +407,7 @@ __metadata:
   resolution: "@keyward/platform-web@workspace:packages/platform-web"
   dependencies:
     "@keyward/core": "workspace:*"
+    fake-indexeddb: "npm:^6.2.5"
     idb: "npm:^8.0.0"
     tsup: "npm:^8.5.0"
     typescript: "npm:^6.0.0"
@@ -1196,6 +1197,13 @@ __metadata:
   version: 3.1.3
   resolution: "exponential-backoff@npm:3.1.3"
   checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
+  languageName: node
+  linkType: hard
+
+"fake-indexeddb@npm:^6.2.5":
+  version: 6.2.5
+  resolution: "fake-indexeddb@npm:6.2.5"
+  checksum: 10c0/6c5e2fe84a61daa06d7ad63699d1041fe61847f15f92db12415634b3db94f363a64be9e08a3c3c4434af9c3c0132086b85c4d5dc5e8e06edae1e7daf70ce1f3c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- **IndexedDBBackend**: `KeywardBackend` implementation over IndexedDB via `idb` library, with lazy connection init and rejected-promise recovery
- **Keyward class**: High-level API (`get`, `set`, `remove`, `wipeUser`) composing `KeyRegistry` + `KeywardBackend`
- **29 tests**: 17 unit tests (in-memory mock backend) + 12 integration tests (`fake-indexeddb`)

## Test plan
- [x] `yarn workspace @keyward/platform-web run test` passes (29/29)
- [x] `yarn workspace @keyward/platform-web run typecheck` passes
- [x] `npx biome check packages/platform-web/src/` passes
- [ ] Verify build: `yarn workspace @keyward/platform-web run build`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)