### PR TITLE
KW-5: implement platform-ios Keychain CRUD + KeyRegistry

### DIFF
--- a/packages/platform-ios/Package.swift
+++ b/packages/platform-ios/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Keyward",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v13), .macOS(.v10_15)],
     products: [
         .library(name: "Keyward", targets: ["Keyward"]),
     ],

--- a/packages/platform-ios/Sources/Keyward/KeyDef.swift
+++ b/packages/platform-ios/Sources/Keyward/KeyDef.swift
@@ -1,0 +1,9 @@
+public struct KeyDef: Equatable, Hashable {
+    public let key: String
+    public let scope: Scope
+
+    public init(key: String, scope: Scope) {
+        self.key = key
+        self.scope = scope
+    }
+}

--- a/packages/platform-ios/Sources/Keyward/KeyRegistry.swift
+++ b/packages/platform-ios/Sources/Keyward/KeyRegistry.swift
@@ -1,0 +1,39 @@
+public class KeyRegistry {
+    private var currentUserId: String?
+
+    public init() {}
+
+    public func setUserId(_ userId: String) {
+        currentUserId = userId
+    }
+
+    public func clearUserId() {
+        currentUserId = nil
+    }
+
+    public func getUserId() -> String? {
+        currentUserId
+    }
+
+    public func resolve(_ keyDef: KeyDef) throws -> String {
+        switch keyDef.scope {
+        case .user:
+            guard let userId = currentUserId else {
+                throw KeywardError.userIdNotSet
+            }
+            return "u/\(userId)/\(keyDef.key)"
+        case .device:
+            return "d/\(keyDef.key)"
+        case .global:
+            return keyDef.key
+        }
+    }
+
+    public static func getUserPrefix(_ userId: String) -> String {
+        "u/\(userId)/"
+    }
+
+    public func getUserPrefix(_ userId: String) -> String {
+        Self.getUserPrefix(userId)
+    }
+}

--- a/packages/platform-ios/Sources/Keyward/KeychainBackend.swift
+++ b/packages/platform-ios/Sources/Keyward/KeychainBackend.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Security
+
+protocol KeychainBackend {
+    func set(key: String, value: String) throws
+    func get(key: String) -> String?
+    func remove(key: String)
+    func allKeys() -> [String]
+    func clear()
+}
+
+final class SystemKeychainBackend: KeychainBackend {
+    private let service = "keyward"
+
+    func set(key: String, value: String) throws {
+        let data = Data(value.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            kSecAttrSynchronizable as String: kCFBooleanFalse!,
+        ]
+
+        let addStatus = SecItemAdd(query as CFDictionary, nil)
+        if addStatus == errSecDuplicateItem {
+            let update: [String: Any] = [kSecValueData as String: data]
+            let matchQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecAttrAccount as String: key,
+            ]
+            let updateStatus = SecItemUpdate(matchQuery as CFDictionary, update as CFDictionary)
+            guard updateStatus == errSecSuccess else {
+                throw KeywardError.keychainWrite(updateStatus)
+            }
+        } else if addStatus != errSecSuccess {
+            throw KeywardError.keychainWrite(addStatus)
+        }
+    }
+
+    func get(key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func remove(key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    func allKeys() -> [String] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let items = result as? [[String: Any]] else { return [] }
+        return items.compactMap { $0[kSecAttrAccount as String] as? String }
+    }
+
+    func clear() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/packages/platform-ios/Sources/Keyward/Keyward.swift
+++ b/packages/platform-ios/Sources/Keyward/Keyward.swift
@@ -1,0 +1,51 @@
+public final class Keyward {
+    static var backend: KeychainBackend = SystemKeychainBackend()
+
+    // MARK: - High-level API (native iOS consumers)
+
+    public static func get(_ keyDef: KeyDef, registry: KeyRegistry) throws -> String? {
+        let resolvedKey = try registry.resolve(keyDef)
+        return getRaw(key: resolvedKey)
+    }
+
+    public static func set(_ keyDef: KeyDef, value: String, registry: KeyRegistry) throws {
+        let resolvedKey = try registry.resolve(keyDef)
+        try setRaw(key: resolvedKey, value: value)
+    }
+
+    public static func remove(_ keyDef: KeyDef, registry: KeyRegistry) throws {
+        let resolvedKey = try registry.resolve(keyDef)
+        removeRaw(key: resolvedKey)
+    }
+
+    public static func keys() -> [String] {
+        backend.allKeys()
+    }
+
+    public static func wipeUser(_ userId: String) {
+        let prefix = KeyRegistry.getUserPrefix(userId)
+        for key in keys() where key.hasPrefix(prefix) {
+            removeRaw(key: key)
+        }
+    }
+
+    // MARK: - Raw API (Capacitor bridge)
+
+    public static func getRaw(key: String) -> String? {
+        backend.get(key: key)
+    }
+
+    public static func setRaw(key: String, value: String) throws {
+        try backend.set(key: key, value: value)
+    }
+
+    public static func removeRaw(key: String) {
+        backend.remove(key: key)
+    }
+
+    public static func clearAll() {
+        backend.clear()
+    }
+
+    private init() {}
+}

--- a/packages/platform-ios/Sources/Keyward/KeywardError.swift
+++ b/packages/platform-ios/Sources/Keyward/KeywardError.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum KeywardError: Error, LocalizedError, Equatable {
+    case userIdNotSet
+    case keychainWrite(OSStatus)
+
+    public var errorDescription: String? {
+        switch self {
+        case .userIdNotSet:
+            return "Keyward: userId not set."
+        case .keychainWrite(let status):
+            return "Keyward: Keychain write failed with status \(status)"
+        }
+    }
+}

--- a/packages/platform-ios/Sources/Keyward/Scope.swift
+++ b/packages/platform-ios/Sources/Keyward/Scope.swift
@@ -1,0 +1,5 @@
+public enum Scope {
+    case user
+    case device
+    case global
+}

--- a/packages/platform-ios/Tests/KeywardTests/KeyRegistryTests.swift
+++ b/packages/platform-ios/Tests/KeywardTests/KeyRegistryTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import Keyward
+
+final class KeyRegistryTests: XCTestCase {
+
+    private var registry: KeyRegistry!
+
+    override func setUp() {
+        super.setUp()
+        registry = KeyRegistry()
+    }
+
+    // MARK: - Scope enum
+
+    func testScopeHasThreeCases() {
+        let cases: [Scope] = [.user, .device, .global]
+        XCTAssertEqual(cases.count, 3)
+    }
+
+    // MARK: - userId management
+
+    func testReturnsNilInitially() {
+        XCTAssertNil(registry.getUserId())
+    }
+
+    func testStoresUserIdAfterSetUserId() {
+        registry.setUserId("alice")
+        XCTAssertEqual(registry.getUserId(), "alice")
+    }
+
+    func testAllowsChangingUserIdWithSubsequentCalls() {
+        registry.setUserId("alice")
+        registry.setUserId("bob")
+        XCTAssertEqual(registry.getUserId(), "bob")
+    }
+
+    func testResetsUserIdToNilAfterClearUserId() {
+        registry.setUserId("alice")
+        registry.clearUserId()
+        XCTAssertNil(registry.getUserId())
+    }
+
+    func testDoesNotThrowWhenClearUserIdCalledWithoutUserId() {
+        registry.clearUserId()
+        XCTAssertNil(registry.getUserId())
+    }
+
+    // MARK: - resolve: Scope.user
+
+    func testUserScopeResolvesToPrefixedKey() throws {
+        registry.setUserId("alice")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "theme", scope: .user)), "u/alice/theme")
+    }
+
+    func testUserScopeThrowsWhenUserIdNotSet() {
+        XCTAssertThrowsError(try registry.resolve(KeyDef(key: "theme", scope: .user))) { error in
+            XCTAssertEqual((error as? KeywardError), .userIdNotSet)
+            XCTAssertEqual(error.localizedDescription, "Keyward: userId not set.")
+        }
+    }
+
+    func testUserScopeThrowsAfterUserIdCleared() {
+        registry.setUserId("alice")
+        registry.clearUserId()
+        XCTAssertThrowsError(try registry.resolve(KeyDef(key: "theme", scope: .user))) { error in
+            XCTAssertEqual((error as? KeywardError), .userIdNotSet)
+        }
+    }
+
+    func testUserScopeUsesCurrentUserIdAfterChange() throws {
+        registry.setUserId("alice")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "theme", scope: .user)), "u/alice/theme")
+        registry.setUserId("bob")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "theme", scope: .user)), "u/bob/theme")
+    }
+
+    // MARK: - resolve: Scope.device
+
+    func testDeviceScopeResolvesToPrefixedKey() throws {
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "volume", scope: .device)), "d/volume")
+    }
+
+    func testDeviceScopeDoesNotIncludeUserId() throws {
+        registry.setUserId("alice")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "volume", scope: .device)), "d/volume")
+    }
+
+    // MARK: - resolve: Scope.global
+
+    func testGlobalScopeResolvesToBareKey() throws {
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "app-version", scope: .global)), "app-version")
+    }
+
+    func testGlobalScopeDoesNotIncludeUserId() throws {
+        registry.setUserId("alice")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "app-version", scope: .global)), "app-version")
+    }
+
+    // MARK: - resolve: edge cases
+
+    func testEmptyStringKeyGlobal() throws {
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "", scope: .global)), "")
+    }
+
+    func testEmptyStringKeyDevice() throws {
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "", scope: .device)), "d/")
+    }
+
+    func testEmptyStringKeyUser() throws {
+        registry.setUserId("alice")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "", scope: .user)), "u/alice/")
+    }
+
+    func testKeyWithSlashes() throws {
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "a/b/c", scope: .device)), "d/a/b/c")
+    }
+
+    func testKeyWithSpecialCharacters() throws {
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "settings.theme@v2", scope: .global)), "settings.theme@v2")
+    }
+
+    func testUserIdWithSpecialCharacters() throws {
+        registry.setUserId("user@example.com")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "prefs", scope: .user)), "u/user@example.com/prefs")
+    }
+
+    func testKeyWithSpaces() throws {
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "my key", scope: .device)), "d/my key")
+    }
+
+    func testKeyWithUnicodeCharacters() throws {
+        registry.setUserId("alice")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "tema-\u{00e7}", scope: .user)), "u/alice/tema-\u{00e7}")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "tema-\u{00e7}", scope: .device)), "d/tema-\u{00e7}")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "tema-\u{00e7}", scope: .global)), "tema-\u{00e7}")
+    }
+
+    // MARK: - getUserPrefix
+
+    func testGetUserPrefixFormat() {
+        XCTAssertEqual(registry.getUserPrefix("alice"), "u/alice/")
+    }
+
+    func testGetUserPrefixWithSpecialCharacters() {
+        XCTAssertEqual(registry.getUserPrefix("user@example.com"), "u/user@example.com/")
+    }
+
+    func testGetUserPrefixIsIndependentOfState() {
+        XCTAssertEqual(registry.getUserPrefix("bob"), "u/bob/")
+    }
+
+    func testGetUserPrefixMatchesResolveOutput() throws {
+        registry.setUserId("alice")
+        let resolved = try registry.resolve(KeyDef(key: "theme", scope: .user))
+        XCTAssertTrue(resolved.hasPrefix(registry.getUserPrefix("alice")))
+    }
+
+    // MARK: - instance isolation
+
+    func testSeparateInstancesDoNotShareState() throws {
+        let other = KeyRegistry()
+        registry.setUserId("alice")
+        other.setUserId("bob")
+        XCTAssertEqual(try registry.resolve(KeyDef(key: "k", scope: .user)), "u/alice/k")
+        XCTAssertEqual(try other.resolve(KeyDef(key: "k", scope: .user)), "u/bob/k")
+    }
+}

--- a/packages/platform-ios/Tests/KeywardTests/KeywardTests.swift
+++ b/packages/platform-ios/Tests/KeywardTests/KeywardTests.swift
@@ -1,0 +1,199 @@
+import XCTest
+@testable import Keyward
+
+final class InMemoryBackend: KeychainBackend {
+    private var store: [String: String] = [:]
+
+    func set(key: String, value: String) throws {
+        store[key] = value
+    }
+
+    func get(key: String) -> String? {
+        store[key]
+    }
+
+    func remove(key: String) {
+        store.removeValue(forKey: key)
+    }
+
+    func allKeys() -> [String] {
+        Array(store.keys)
+    }
+
+    func clear() {
+        store.removeAll()
+    }
+}
+
+final class KeywardTests: XCTestCase {
+
+    private var registry: KeyRegistry!
+
+    override func setUp() {
+        super.setUp()
+        Keyward.backend = InMemoryBackend()
+        registry = KeyRegistry()
+    }
+
+    // MARK: - userId management
+
+    func testReturnsNilInitially() {
+        XCTAssertNil(registry.getUserId())
+    }
+
+    func testStoresUserIdAfterSetUserId() {
+        registry.setUserId("alice")
+        XCTAssertEqual(registry.getUserId(), "alice")
+    }
+
+    func testResetsUserIdAfterClearUserId() {
+        registry.setUserId("alice")
+        registry.clearUserId()
+        XCTAssertNil(registry.getUserId())
+    }
+
+    // MARK: - get / set / remove
+
+    func testReturnsNilForMissingKey() throws {
+        let result = try Keyward.get(KeyDef(key: "app-version", scope: .global), registry: registry)
+        XCTAssertNil(result)
+    }
+
+    func testStoresAndRetrievesGlobalScopedValue() throws {
+        try Keyward.set(KeyDef(key: "app-version", scope: .global), value: "1.0", registry: registry)
+        let result = try Keyward.get(KeyDef(key: "app-version", scope: .global), registry: registry)
+        XCTAssertEqual(result, "1.0")
+    }
+
+    func testStoresAndRetrievesDeviceScopedValue() throws {
+        try Keyward.set(KeyDef(key: "volume", scope: .device), value: "80", registry: registry)
+        let result = try Keyward.get(KeyDef(key: "volume", scope: .device), registry: registry)
+        XCTAssertEqual(result, "80")
+    }
+
+    func testStoresAndRetrievesUserScopedValue() throws {
+        registry.setUserId("alice")
+        try Keyward.set(KeyDef(key: "theme", scope: .user), value: "dark", registry: registry)
+        let result = try Keyward.get(KeyDef(key: "theme", scope: .user), registry: registry)
+        XCTAssertEqual(result, "dark")
+    }
+
+    func testThrowsWhenAccessingUserScopedKeyWithoutUserId() {
+        XCTAssertThrowsError(try Keyward.get(KeyDef(key: "theme", scope: .user), registry: registry)) { error in
+            XCTAssertEqual((error as? KeywardError), .userIdNotSet)
+        }
+    }
+
+    func testRemovesValue() throws {
+        try Keyward.set(KeyDef(key: "app-version", scope: .global), value: "1.0", registry: registry)
+        try Keyward.remove(KeyDef(key: "app-version", scope: .global), registry: registry)
+        let result = try Keyward.get(KeyDef(key: "app-version", scope: .global), registry: registry)
+        XCTAssertNil(result)
+    }
+
+    func testRemovingNonExistentKeyDoesNotThrow() throws {
+        try Keyward.remove(KeyDef(key: "nope", scope: .global), registry: registry)
+    }
+
+    func testOverwritesExistingValue() throws {
+        try Keyward.set(KeyDef(key: "lang", scope: .global), value: "en", registry: registry)
+        try Keyward.set(KeyDef(key: "lang", scope: .global), value: "tr", registry: registry)
+        let result = try Keyward.get(KeyDef(key: "lang", scope: .global), registry: registry)
+        XCTAssertEqual(result, "tr")
+    }
+
+    // MARK: - user isolation
+
+    func testDifferentUsersHaveSeparateValues() throws {
+        registry.setUserId("alice")
+        try Keyward.set(KeyDef(key: "theme", scope: .user), value: "dark", registry: registry)
+        registry.setUserId("bob")
+        try Keyward.set(KeyDef(key: "theme", scope: .user), value: "light", registry: registry)
+
+        registry.setUserId("alice")
+        XCTAssertEqual(try Keyward.get(KeyDef(key: "theme", scope: .user), registry: registry), "dark")
+        registry.setUserId("bob")
+        XCTAssertEqual(try Keyward.get(KeyDef(key: "theme", scope: .user), registry: registry), "light")
+    }
+
+    func testUserScopedKeysDoNotCollideWithDeviceScoped() throws {
+        registry.setUserId("alice")
+        try Keyward.set(KeyDef(key: "volume", scope: .user), value: "50", registry: registry)
+        try Keyward.set(KeyDef(key: "volume", scope: .device), value: "80", registry: registry)
+
+        XCTAssertEqual(try Keyward.get(KeyDef(key: "volume", scope: .user), registry: registry), "50")
+        XCTAssertEqual(try Keyward.get(KeyDef(key: "volume", scope: .device), registry: registry), "80")
+    }
+
+    // MARK: - wipeUser
+
+    func testWipeUserRemovesAllKeysForUser() throws {
+        registry.setUserId("alice")
+        try Keyward.set(KeyDef(key: "theme", scope: .user), value: "dark", registry: registry)
+        try Keyward.set(KeyDef(key: "lang", scope: .user), value: "tr", registry: registry)
+
+        Keyward.wipeUser("alice")
+
+        XCTAssertNil(try Keyward.get(KeyDef(key: "theme", scope: .user), registry: registry))
+        XCTAssertNil(try Keyward.get(KeyDef(key: "lang", scope: .user), registry: registry))
+    }
+
+    func testWipeUserDoesNotRemoveOtherUsersKeys() throws {
+        registry.setUserId("alice")
+        try Keyward.set(KeyDef(key: "theme", scope: .user), value: "dark", registry: registry)
+        registry.setUserId("bob")
+        try Keyward.set(KeyDef(key: "theme", scope: .user), value: "light", registry: registry)
+
+        Keyward.wipeUser("alice")
+
+        registry.setUserId("bob")
+        XCTAssertEqual(try Keyward.get(KeyDef(key: "theme", scope: .user), registry: registry), "light")
+    }
+
+    func testWipeUserDoesNotRemoveDeviceOrGlobalKeys() throws {
+        registry.setUserId("alice")
+        try Keyward.set(KeyDef(key: "theme", scope: .user), value: "dark", registry: registry)
+        try Keyward.set(KeyDef(key: "volume", scope: .device), value: "80", registry: registry)
+        try Keyward.set(KeyDef(key: "app-version", scope: .global), value: "1.0", registry: registry)
+
+        Keyward.wipeUser("alice")
+
+        XCTAssertEqual(try Keyward.get(KeyDef(key: "volume", scope: .device), registry: registry), "80")
+        XCTAssertEqual(try Keyward.get(KeyDef(key: "app-version", scope: .global), registry: registry), "1.0")
+    }
+
+    func testWipeUserIsNoOpForUserWithNoKeys() {
+        Keyward.wipeUser("nobody")
+    }
+
+    // MARK: - raw API
+
+    func testSetRawAndGetRaw() throws {
+        try Keyward.setRaw(key: "raw-key", value: "raw-value")
+        XCTAssertEqual(Keyward.getRaw(key: "raw-key"), "raw-value")
+    }
+
+    func testGetRawReturnsNilForMissingKey() {
+        XCTAssertNil(Keyward.getRaw(key: "missing"))
+    }
+
+    func testRemoveRaw() throws {
+        try Keyward.setRaw(key: "raw-key", value: "raw-value")
+        Keyward.removeRaw(key: "raw-key")
+        XCTAssertNil(Keyward.getRaw(key: "raw-key"))
+    }
+
+    func testClearAll() throws {
+        try Keyward.setRaw(key: "a", value: "1")
+        try Keyward.setRaw(key: "b", value: "2")
+        Keyward.clearAll()
+        XCTAssertTrue(Keyward.keys().isEmpty)
+    }
+
+    func testKeysReturnsAllStoredKeys() throws {
+        try Keyward.setRaw(key: "x", value: "1")
+        try Keyward.setRaw(key: "y", value: "2")
+        let keys = Keyward.keys().sorted()
+        XCTAssertEqual(keys, ["x", "y"])
+    }
+}


### PR DESCRIPTION
## Summary
- Pure Swift library (SPM, iOS 13+ / macOS 10.15+) implementing Keychain-backed secure storage
- Scope enum, KeyDef struct, KeywardError, KeyRegistry (TypeScript core port)
- Keyward static API: high-level (get/set/remove/keys/wipeUser) + raw bridge methods (getRaw/setRaw/removeRaw/clearAll)
- Internal KeychainBackend protocol with SystemKeychainBackend (add-first, update-on-duplicate pattern)
- 49 XCTest tests via InMemoryBackend (27 KeyRegistry + 22 Keyward), all passing

## Test plan
- [x] `cd packages/platform-ios && swift test` passes (49/49)
- [ ] Verify codegen Swift template output matches public API (KeyDef, Scope, import Keyward)
- [ ] Integration test on real iOS device/simulator with Keychain entitlements