### PR TITLE
KW-24: fix iOS module name to Keyward

### DIFF
--- a/packages/capacitor/DaflanKeywardCapacitor.podspec
+++ b/packages/capacitor/DaflanKeywardCapacitor.podspec
@@ -4,6 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name = 'DaflanKeywardCapacitor'
+  s.module_name = 'Keyward'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']


### PR DESCRIPTION
## Summary

- Add `s.module_name = 'Keyward'` to `DaflanKeywardCapacitor.podspec`
- Allows `import Keyward` in consumer apps and codegen output
- Without this, the module defaults to `DaflanKeywardCapacitor`

## Test plan

- [x] `pod install` succeeds
- [x] `import Keyward` compiles in consumer app
- [x] Codegen Swift output (`import Keyward`) compiles without modification

Closes #24