### PR TITLE
KW-26: bundle platform-android sources in capacitor plugin

### DIFF
--- a/packages/capacitor/.gitignore
+++ b/packages/capacitor/.gitignore
@@ -1,5 +1,8 @@
 # Copied from platform-ios at pack time (see prepack script)
 ios/Sources/Keyward/
 
+# Copied from platform-android at pack time (see prepack script)
+android/src/main/java/org/keyward/*.java
+
 # SPM build cache
 ios/.build/

--- a/packages/capacitor/android/build.gradle
+++ b/packages/capacitor/android/build.gradle
@@ -21,7 +21,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.keyward:platform-android:0.0.1'
     implementation 'com.capacitorjs:core:8.+'
     implementation 'androidx.security:security-crypto:1.1.0-alpha06'
 }

--- a/packages/capacitor/package.json
+++ b/packages/capacitor/package.json
@@ -35,10 +35,11 @@
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist ios/Sources/Keyward",
+    "clean": "rm -rf dist ios/Sources/Keyward && find android/src/main/java/org/keyward -maxdepth 1 -name '*.java' -delete 2>/dev/null; true",
     "prepare:ios": "test -d ../platform-ios/Sources/Keyward && rm -rf ios/Sources/Keyward && cp -r ../platform-ios/Sources/Keyward ios/Sources/Keyward",
-    "prepack": "yarn prepare:ios",
-    "postpack": "rm -rf ios/Sources/Keyward"
+    "prepare:android": "test -d ../platform-android/src/main/java/org/keyward && cp ../platform-android/src/main/java/org/keyward/*.java android/src/main/java/org/keyward/",
+    "prepack": "yarn prepare:ios && yarn prepare:android",
+    "postpack": "rm -rf ios/Sources/Keyward && find android/src/main/java/org/keyward -maxdepth 1 -name '*.java' -delete 2>/dev/null; true"
   },
   "peerDependencies": {
     "@capacitor/core": "^8.0.0"


### PR DESCRIPTION
## Summary

- Remove Maven dependency on `org.keyward:platform-android` (artifact was never published)
- Add `prepare:android` prepack script to copy platform-android Java sources at pack time
- Update `clean`/`postpack` to handle Android copied sources
- Add Android copied sources to `.gitignore`

Same approach as iOS: native sources bundled in npm package, no external registry dependency.

## Test plan

- [x] `yarn pack` includes platform-android Java sources in tarball
- [x] `postpack` cleans up copied sources
- [x] Android build succeeds without Maven dependency (`./gradlew assembleDebug`)
- [x] CI passes

Closes #26