### PR TITLE
KW-26: add missing storageFailed method to KeywardException

### DIFF
--- a/packages/platform-android/src/main/java/org/keyward/KeywardException.java
+++ b/packages/platform-android/src/main/java/org/keyward/KeywardException.java
@@ -16,4 +16,8 @@ public final class KeywardException extends Exception {
     public static KeywardException storageWrite(Throwable cause) {
         return new KeywardException("Keyward: storage write failed.", cause);
     }
+
+    public static KeywardException storageFailed(String key) {
+        return new KeywardException("Keyward: storage operation failed for key: " + key);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `KeywardException.storageFailed(String key)` factory method
- `EncryptedPrefsBackend.set()` calls this method but it didn't exist, causing Android build failure

## Test plan

- [x] Android build compiles without errors
- [x] CI passes

Relates to #26