### PR TITLE
KW-26: fix Android namespace conflict with Capacitor core

### DIFF
--- a/packages/capacitor/android/build.gradle
+++ b/packages/capacitor/android/build.gradle
@@ -21,6 +21,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.capacitorjs:core:8.+'
+    compileOnly project(':capacitor-android')
     implementation 'androidx.security:security-crypto:1.1.0-alpha06'
 }


### PR DESCRIPTION
## Summary

- Replace `implementation 'com.capacitorjs:core:8.+'` with `compileOnly project(':capacitor-android')`
- Follows Capacitor plugin convention (same as @capacitor/app, @capacitor/device, etc.)
- Fixes namespace collision: `com.getcapacitor.android` used in both `:capacitor-android` and `com.capacitorjs:core`

## Test plan

- [x] `./gradlew assembleDebug` succeeds without namespace conflict
- [x] CI passes

Relates to #26