### PR TITLE
KW-28: Biome config migration, release script improvements, v0.0.8 bump

### DIFF
--- a/packages/capacitor/package.json
+++ b/packages/capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daflan/keyward-capacitor",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Capacitor plugin bridge for Keyward secure storage",
   "license": "MIT",
   "repository": {

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daflan/keyward-codegen",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "CLI to generate type-safe storage key accessors from keyward.keys.json",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daflan/keyward-core",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Platform-agnostic types and key registry for Keyward",
   "license": "MIT",
   "repository": {

--- a/packages/platform-android/build.gradle
+++ b/packages/platform-android/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.keyward'
-version = '0.0.7'
+version = '0.0.8'
 
 repositories {
     mavenCentral()

--- a/packages/platform-android/package.json
+++ b/packages/platform-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyward/platform-android",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "scripts": {
     "test": "./gradlew test"

--- a/packages/platform-ios/package.json
+++ b/packages/platform-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyward/platform-ios",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "scripts": {
     "test": "swift test"

--- a/packages/platform-web/package.json
+++ b/packages/platform-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daflan/keyward-platform-web",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Web storage backend for Keyward (IndexedDB + WebCrypto)",
   "license": "MIT",
   "repository": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,22 +1,53 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="${1:-}"
-
-if [[ -z "$VERSION" ]]; then
-  echo "Usage: yarn release <version>"
-  echo "Example: yarn release 0.0.4"
-  exit 1
-fi
-
-if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Error: version must be semver (e.g. 0.0.4)"
-  exit 1
-fi
-
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-echo "Bumping all packages to v${VERSION}..."
+# Read current version from core package
+CURRENT=$(grep -m1 '"version"' "${ROOT}/packages/core/package.json" | sed 's/.*"version": "\([^"]*\)".*/\1/')
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+ARG="${1:-}"
+
+case "$ARG" in
+  patch)  PATCH=$((PATCH + 1)) ;;
+  minor)  MINOR=$((MINOR + 1)); PATCH=0 ;;
+  major)  MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  "")
+    # Default: suggest patch bump and ask for confirmation
+    PATCH=$((PATCH + 1))
+    VERSION="${MAJOR}.${MINOR}.${PATCH}"
+    echo "Current version: v${CURRENT}"
+    echo ""
+    printf "Release v${VERSION}? [Y/n/version]: "
+    read -r REPLY
+    case "$REPLY" in
+      ""|[Yy]|[Yy]es) ;; # proceed with patch
+      [Nn]|[Nn]o) echo "Aborted."; exit 0 ;;
+      *)
+        if [[ ! "$REPLY" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Error: must be semver (e.g. 0.1.0)"
+          exit 1
+        fi
+        IFS='.' read -r MAJOR MINOR PATCH <<< "$REPLY"
+        ;;
+    esac
+    ;;
+  *)
+    if [[ ! "$ARG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "Error: version must be patch, minor, major, or semver (e.g. 0.1.0)"
+      exit 1
+    fi
+    IFS='.' read -r MAJOR MINOR PATCH <<< "$ARG"
+    ;;
+esac
+
+VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+echo ""
+echo "Bumping all packages: v${CURRENT} -> v${VERSION}"
+echo ""
 
 # npm packages
 for PKG in core platform-web codegen capacitor platform-ios platform-android; do


### PR DESCRIPTION
## Summary
- Migrate biome.json config to 2.4.11 schema (replace deprecated `experimentalScannerIgnores`)
- Add interactive version prompt to release script (`yarn release` now auto-detects current version and suggests patch bump)
- Bump all packages to v0.0.8

## Test plan
- [x] `yarn test`, `yarn build`, `yarn lint` all pass

Follows up on #34.
Closes #32.