### PR TITLE
KW-30: publish keyward-recovery packages to npm (release wiring)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           FAILED=0
-          for PKG in core platform-web codegen capacitor; do
+          for PKG in core platform-web codegen capacitor recovery-core recovery-capacitor; do
             PKG_VERSION=$(node -p "require('./packages/${PKG}/package.json').version")
             if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
               echo "::error::packages/${PKG} version ($PKG_VERSION) != tag ($TAG_VERSION)"
@@ -70,6 +70,25 @@ jobs:
 
       - name: Pack and publish @daflan/keyward-capacitor
         working-directory: packages/capacitor
+        run: |
+          yarn pack --out package.tgz
+          npm publish package.tgz --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Recovery packages. recovery-core must publish before recovery-capacitor,
+      # which declares it as a dependency (workspace:* is resolved to the concrete
+      # version at pack time).
+      - name: Pack and publish @daflan/keyward-recovery-core
+        working-directory: packages/recovery-core
+        run: |
+          yarn pack --out package.tgz
+          npm publish package.tgz --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Pack and publish @daflan/keyward-recovery
+        working-directory: packages/recovery-capacitor
         run: |
           yarn pack --out package.tgz
           npm publish package.tgz --provenance --access public

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,8 +49,9 @@ echo ""
 echo "Bumping all packages: v${CURRENT} -> v${VERSION}"
 echo ""
 
-# npm packages
-for PKG in core platform-web codegen capacitor platform-ios platform-android; do
+# npm packages (storage + recovery)
+for PKG in core platform-web codegen capacitor platform-ios platform-android \
+           recovery-core recovery-capacitor platform-ios-recovery platform-android-recovery; do
   PKG_JSON="${ROOT}/packages/${PKG}/package.json"
   if [[ -f "$PKG_JSON" ]]; then
     sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" "$PKG_JSON"
@@ -58,12 +59,14 @@ for PKG in core platform-web codegen capacitor platform-ios platform-android; do
   fi
 done
 
-# Android build.gradle
-GRADLE="${ROOT}/packages/platform-android/build.gradle"
-if [[ -f "$GRADLE" ]]; then
-  sed -i '' "s/version = '[^']*'/version = '${VERSION}'/" "$GRADLE"
-  echo "  packages/platform-android/build.gradle -> ${VERSION}"
-fi
+# Android build.gradle (storage + recovery native libs)
+for GRADLE_PKG in platform-android platform-android-recovery; do
+  GRADLE="${ROOT}/packages/${GRADLE_PKG}/build.gradle"
+  if [[ -f "$GRADLE" ]]; then
+    sed -i '' "s/version = '[^']*'/version = '${VERSION}'/" "$GRADLE"
+    echo "  packages/${GRADLE_PKG}/build.gradle -> ${VERSION}"
+  fi
+done
 
 # Capacitor Android build.gradle (has its own version via plugin)
 CAP_GRADLE="${ROOT}/packages/capacitor/android/build.gradle"


### PR DESCRIPTION
## Summary

Wires the `keyward-recovery` packages (added in KW-29) into the release and publish tooling so `@daflan/keyward-recovery` and `@daflan/keyward-recovery-core` actually reach npm. They are currently 404 on npm: the `v0.0.9` tag was pushed before KW-29 merged, and neither `release.sh` nor `publish.yml` knew about the recovery packages.

## Changes

- **`scripts/release.sh`**: bump `recovery-core`, `recovery-capacitor` and the native `platform-*-recovery` package.json versions alongside storage; bump `platform-android-recovery/build.gradle`.
- **`.github/workflows/publish.yml`**: validate the recovery package versions against the tag, and add `Pack and publish` steps for `@daflan/keyward-recovery-core` and `@daflan/keyward-recovery`. `recovery-core` publishes before `recovery-capacitor`, which depends on it (`workspace:*` resolves to the concrete version at pack time).

## Affected Packages

- [x] `@daflan/keyward-recovery-core` (now published)
- [x] `@daflan/keyward-recovery` (now published)

## Type

- [x] CI / tooling

## Checklist

- [x] Tests added/updated (n/a - release tooling)
- [x] `yarn build` passes (recovery-core + recovery-capacitor build green)
- [x] Verified `yarn pack` locally: recovery-capacitor vendors the native iOS/Android sources via prepack, and `workspace:*` resolves to a concrete version in the packed manifest
- [x] `yarn lint` passes
- [x] No breaking changes (additive; new publish targets only)

## Notes

- Native `@keyward/platform-ios-recovery` / `@keyward/platform-android-recovery` stay unpublished to npm - they are vendored into `recovery-capacitor` at prepack, mirroring how storage handles `platform-ios` / `platform-android`.
- After merge: bump all packages to `v0.0.10` on `main`, tag `v0.0.10`, push - the Publish workflow then ships the recovery packages to npm for the first time.

Closes #38. Refs #36.
