### PR TITLE
KW-31: fix recovery-capacitor iOS podspec name

### DIFF
--- a/packages/recovery-capacitor/DaflanKeywardRecovery.podspec
+++ b/packages/recovery-capacitor/DaflanKeywardRecovery.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'DaflanKeywardRecoveryCapacitor'
+  s.name = 'DaflanKeywardRecovery'
   s.module_name = 'KeywardRecovery'
   s.version = package['version']
   s.summary = package['description']

--- a/packages/recovery-capacitor/package.json
+++ b/packages/recovery-capacitor/package.json
@@ -24,7 +24,7 @@
     "ios/Sources/**",
     "android",
     "Package.swift",
-    "DaflanKeywardRecoveryCapacitor.podspec"
+    "DaflanKeywardRecovery.podspec"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Fixes `cap sync` on iOS for `@daflan/keyward-recovery`. Capacitor derives the pod name from the package name (`@daflan/keyward-recovery` -> `DaflanKeywardRecovery`) and writes `pod 'DaflanKeywardRecovery'` into the app Podfile, but the package shipped `DaflanKeywardRecoveryCapacitor.podspec` (`s.name = 'DaflanKeywardRecoveryCapacitor'`), so CocoaPods failed with `No podspec found for DaflanKeywardRecovery`.

## Changes

- Rename `DaflanKeywardRecoveryCapacitor.podspec` -> `DaflanKeywardRecovery.podspec`.
- `s.name = 'DaflanKeywardRecovery'` (module_name stays `KeywardRecovery`).
- Update the `files` array in package.json.

## Affected Packages

- [x] `@daflan/keyward-recovery`

## Type

- [x] Bug fix

## Checklist

- [x] `yarn pack` verified: tarball ships `DaflanKeywardRecovery.podspec`
- [x] No breaking changes (module_name unchanged; only the pod/podspec name is corrected to what Capacitor expects)

## Notes

Verified against a real consumer (`cap sync` in the Fawa app): Android already resolved the plugin; iOS failed only on this podspec-name mismatch. Requires a v0.0.11 release to reach npm.

Closes #40.
