### PR TITLE
KW-32: fix recovery-capacitor Android plugin compile errors

### DIFF
--- a/packages/recovery-capacitor/android/build.gradle
+++ b/packages/recovery-capacitor/android/build.gradle
@@ -22,6 +22,9 @@ repositories {
 
 dependencies {
     compileOnly project(':capacitor-android')
+    // getActivity() returns an AppCompatActivity (Capacitor BridgeActivity); the
+    // symbol must be on the compile classpath. Provided at runtime by the host app.
+    compileOnly 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.credentials:credentials:1.3.0'
     implementation 'androidx.credentials:credentials-play-services-auth:1.3.0'
 }

--- a/packages/recovery-capacitor/android/src/main/java/org/keyward/recovery/capacitor/KeywardRecoveryPlugin.java
+++ b/packages/recovery-capacitor/android/src/main/java/org/keyward/recovery/capacitor/KeywardRecoveryPlugin.java
@@ -54,7 +54,9 @@ public class KeywardRecoveryPlugin extends Plugin {
 
                     @Override
                     public void onError(Throwable error) {
-                        call.reject("prfRegister failed", error);
+                        call.reject(
+                                "prfRegister failed",
+                                error instanceof Exception ? (Exception) error : new Exception(error));
                     }
                 });
     }
@@ -81,7 +83,9 @@ public class KeywardRecoveryPlugin extends Plugin {
 
                     @Override
                     public void onError(Throwable error) {
-                        call.reject("prfAssert failed", error);
+                        call.reject(
+                                "prfAssert failed",
+                                error instanceof Exception ? (Exception) error : new Exception(error));
                     }
                 });
     }


### PR DESCRIPTION
## Summary

Makes `@daflan/keyward-recovery` compile on Android when consumed in a host app. CI never builds the Android capacitor bridge, so these slipped through KW-29 and only surfaced on `cap run android`.

## Changes

- `KeywardRecoveryPlugin.java`: `call.reject(String, Throwable)` -> convert to Exception (`error instanceof Exception ? (Exception) error : new Exception(error)`); Capacitor `reject` has no Throwable overload.
- `android/build.gradle`: add `compileOnly 'androidx.appcompat:appcompat:1.7.0'` so `getActivity()` (returns `AppCompatActivity`) resolves; runtime provided by the host app.

## Type

- [x] Bug fix

## Verified

Applied identically as a local node_modules edit in the Fawa app: `cap run android` -> gradle BUILD SUCCESSFUL -> deployed to a real OPPO CPH2735 (API 36) -> PRF harness register/assert returned the same prfFirst for the same salt (DETERMINISTIC). iOS was already verified on a real iPhone.

Needs a v0.0.12 release to reach npm.

Closes #42.
