### PR TITLE
feat(KW-33): recovery-code anchor (Anchor 3) in recovery-core

### DIFF
--- a/packages/recovery-capacitor/src/index.ts
+++ b/packages/recovery-capacitor/src/index.ts
@@ -4,14 +4,21 @@ import { NativePrfBridge } from './NativePrfBridge.js';
 import { NativePlugin } from './plugin.js';
 
 export type {
+  Argon2idParams,
   Availability,
+  CodeRecipient,
   Envelope,
   EnvelopeTransport,
   NativePrf,
   Recipient,
   RecipientSpec,
 } from '@daflan/keyward-recovery-core';
-export { KeywardRecoveryError, Recoverable } from '@daflan/keyward-recovery-core';
+export {
+  generateRecoveryCode,
+  KeywardRecoveryError,
+  normalizeRecoveryCode,
+  Recoverable,
+} from '@daflan/keyward-recovery-core';
 export type { KeywardRecoveryNativePlugin } from './definitions.js';
 export { NativePrfBridge } from './NativePrfBridge.js';
 export { NativePlugin } from './plugin.js';

--- a/packages/recovery-core/package.json
+++ b/packages/recovery-core/package.json
@@ -37,5 +37,8 @@
     "tsup": "^8.5.1",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
+  },
+  "dependencies": {
+    "hash-wasm": "^4.12.0"
   }
 }

--- a/packages/recovery-core/src/Recoverable.ts
+++ b/packages/recovery-core/src/Recoverable.ts
@@ -8,8 +8,16 @@ import {
   unwrapDataKey,
   wrapDataKey,
 } from './envelope.js';
+import {
+  type Argon2idParams,
+  argon2idIkm,
+  assertRecoveryCodeStrength,
+  DEFAULT_ARGON2ID_PARAMS,
+  parseArgon2idParams,
+} from './kdf.js';
 import type {
   Availability,
+  CodeRecipient,
   EnrollContext,
   Envelope,
   NativePrf,
@@ -69,6 +77,44 @@ export class Recoverable {
     return openBlob(envelope.blob, dataKey);
   }
 
+  /**
+   * Recover the secret via the recovery-code anchor (Anchor 3): the universal
+   * backstop that works where passkey-PRF is unavailable (no-GMS / de-googled /
+   * iOS < 18.4) and no family member can re-seal. A wrong code fails the AES-GCM
+   * authentication and throws.
+   */
+  async recoverViaCode(scopeKey: string, code: string): Promise<Uint8Array> {
+    const envelope = await this.transport.get(scopeKey);
+    if (!envelope) {
+      throw new KeywardRecoveryError('not_found', `No recovery envelope for "${scopeKey}"`);
+    }
+    const codeRecipients = envelope.recipients.filter((r): r is CodeRecipient => r.kind === 'code');
+    if (codeRecipients.length === 0) {
+      throw new KeywardRecoveryError('no_code_anchor', 'Envelope has no recovery-code recipient');
+    }
+    // An envelope may hold more than one code recipient (e.g. a re-issued code via
+    // addRecipient). Try each; the right code unwraps exactly one, wrong codes fail
+    // the AES-GCM auth and move on.
+    const saltBytes = fromBase64Url(envelope.salt);
+    for (const recipient of codeRecipients) {
+      try {
+        const kek = await this.deriveCodeKek(
+          code,
+          saltBytes,
+          parseArgon2idParams(recipient.params),
+        );
+        const dataKey = await unwrapDataKey(recipient.wrap, kek);
+        return await openBlob(envelope.blob, dataKey);
+      } catch {
+        // Wrong code for this recipient (or malformed params); try the next.
+      }
+    }
+    throw new KeywardRecoveryError(
+      'code_recovery_failed',
+      'No recovery-code recipient matched the provided code',
+    );
+  }
+
   /** Which recovery anchors are usable on this device. */
   async availability(): Promise<Availability> {
     return { passkey: await this.native.capabilities() };
@@ -115,13 +161,28 @@ export class Recoverable {
         const wrap = await wrapDataKey(dataKey, kek);
         return { kind: 'social', memberId: spec.memberId, wrap };
       }
-      case 'code':
-        // Deferred in v1 (Argon2id is not in WebCrypto). The format reserves the kind.
-        throw new KeywardRecoveryError(
-          'code_recipient_deferred',
-          'recovery-code recipient is not implemented in v1',
+      case 'code': {
+        // Anchor 3: KEK = HKDF(Argon2id(code, envelope.salt, params)). The params
+        // are stored on the recipient so recoverViaCode reproduces the derivation.
+        assertRecoveryCodeStrength(spec.code);
+        const kek = await this.deriveCodeKek(
+          spec.code,
+          fromBase64Url(salt),
+          DEFAULT_ARGON2ID_PARAMS,
         );
+        const wrap = await wrapDataKey(dataKey, kek);
+        return { kind: 'code', kdf: 'argon2id', params: { ...DEFAULT_ARGON2ID_PARAMS }, wrap };
+      }
     }
+  }
+
+  /** code -> KEK: HKDF-SHA256(Argon2id(normalize(code), salt, params)). */
+  private async deriveCodeKek(
+    code: string,
+    salt: Uint8Array,
+    params: Argon2idParams,
+  ): Promise<CryptoKey> {
+    return deriveKek(await argon2idIkm(code, salt, params));
   }
 
   /** Enroll (or reuse) the user passkey and obtain a PRF output for `salt`. */

--- a/packages/recovery-core/src/index.ts
+++ b/packages/recovery-core/src/index.ts
@@ -11,6 +11,14 @@ export {
   unwrapDataKey,
   wrapDataKey,
 } from './envelope.js';
+export type { Argon2idParams } from './kdf.js';
+export {
+  argon2idIkm,
+  DEFAULT_ARGON2ID_PARAMS,
+  generateRecoveryCode,
+  normalizeRecoveryCode,
+  parseArgon2idParams,
+} from './kdf.js';
 export { KeywardRecoveryError, Recoverable } from './Recoverable.js';
 export type {
   Availability,

--- a/packages/recovery-core/src/kdf.ts
+++ b/packages/recovery-core/src/kdf.ts
@@ -1,0 +1,140 @@
+/**
+ * Recovery-code (Anchor 3) key derivation and code formatting.
+ *
+ * The code is a high-entropy random string (>=128-bit). Its KEK is
+ * `HKDF-SHA256(Argon2id(normalize(code), envelope.salt, params))`. Argon2id's
+ * memory-hardness is defense-in-depth here: a full-entropy code is already
+ * infeasible to brute-force, so the parameters are tuned for mobile webviews.
+ *
+ * This is the one KDF dependency recovery-core takes beyond WebCrypto (hash-wasm's
+ * Argon2id, whose WASM is inlined so there is no asset to serve); everything else
+ * stays WebCrypto-only.
+ */
+import { argon2id } from 'hash-wasm';
+import { randomBytes } from './envelope.js';
+
+/** Argon2id parameters, stored verbatim in the code recipient so recover reproduces them. */
+export interface Argon2idParams {
+  /** memory cost, KiB */
+  readonly m: number;
+  /** time cost, iterations */
+  readonly t: number;
+  /** parallelism (lanes) */
+  readonly p: number;
+  /** argon2 version (0x13 = 19) */
+  readonly v: number;
+}
+
+/** hash-wasm's Argon2id is fixed at version 0x13 (19); we can only produce/consume this. */
+const ARGON2_VERSION = 19;
+
+/** OWASP Argon2id interactive minimum; safe on mobile webviews (~150ms, ~19 MB transient). */
+export const DEFAULT_ARGON2ID_PARAMS: Argon2idParams = {
+  m: 19456,
+  t: 2,
+  p: 1,
+  v: ARGON2_VERSION,
+};
+
+/**
+ * Bounds for envelope-supplied params. They guard corrupted/tampered records:
+ * reject nonsense that would throw deep inside argon2id or OOM the webview, and
+ * surface a clean error instead. Generous enough for any legitimate tuning.
+ */
+const ARGON2_BOUNDS = {
+  m: { min: 1024, max: 1_048_576 }, // 1 MiB .. 1 GiB
+  t: { min: 1, max: 32 },
+  p: { min: 1, max: 16 },
+} as const;
+
+/** Crockford base32 alphabet (excludes I, L, O, U to avoid ambiguity). */
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+/** 28 symbols x 5 bits = 140-bit (>= the 128-bit floor), formatted as 7 groups of 4. */
+const CODE_SYMBOLS = 28;
+const GROUP_SIZE = 4;
+
+function requireIntInRange(value: unknown, min: number, max: number, name: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`recovery-core: malformed argon2id params (${name})`);
+  }
+  return value;
+}
+
+/**
+ * Read + validate Argon2id params from an opaque recipient `params` record.
+ * m/t/p must be positive integers within {@link ARGON2_BOUNDS}, and the version
+ * must be the one this build supports (0x13) so a mismatch fails clearly rather
+ * than silently deriving a wrong IKM.
+ */
+export function parseArgon2idParams(params: Record<string, unknown>): Argon2idParams {
+  const m = requireIntInRange(params.m, ARGON2_BOUNDS.m.min, ARGON2_BOUNDS.m.max, 'm');
+  const t = requireIntInRange(params.t, ARGON2_BOUNDS.t.min, ARGON2_BOUNDS.t.max, 't');
+  const p = requireIntInRange(params.p, ARGON2_BOUNDS.p.min, ARGON2_BOUNDS.p.max, 'p');
+  if (params.v !== ARGON2_VERSION) {
+    throw new Error(`recovery-core: unsupported argon2id version (expected ${ARGON2_VERSION})`);
+  }
+  return { m, t, p, v: ARGON2_VERSION };
+}
+
+/**
+ * Derive the 32-byte IKM from a recovery code via Argon2id. `salt` is the envelope
+ * salt bytes (per-envelope unique, which is all Argon2 needs). The code is
+ * canonicalized first so minor transcription variance still derives the same IKM.
+ */
+export async function argon2idIkm(
+  code: string,
+  salt: Uint8Array,
+  params: Argon2idParams,
+): Promise<Uint8Array> {
+  return argon2id({
+    password: normalizeRecoveryCode(code),
+    salt,
+    parallelism: params.p,
+    iterations: params.t,
+    memorySize: params.m,
+    hashLength: 32,
+    outputType: 'binary',
+  });
+}
+
+/**
+ * Generate a fresh recovery code: {@link CODE_SYMBOLS} uniform Crockford base32
+ * symbols, formatted in dash-separated groups of {@link GROUP_SIZE}.
+ *
+ * 256 is a multiple of 32, so `byte % 32` is already uniform over the alphabet
+ * with no modulo bias and no rejection needed; one CSPRNG fill covers the code.
+ */
+export function generateRecoveryCode(): string {
+  const bytes = randomBytes(CODE_SYMBOLS);
+  const code = Array.from(bytes, (byte) => CROCKFORD.charAt(byte % 32)).join('');
+  return (code.match(new RegExp(`.{1,${GROUP_SIZE}}`, 'g')) ?? []).join('-');
+}
+
+/**
+ * Canonicalize a user-entered code for the KDF: strip separators/whitespace,
+ * uppercase, and map Crockford confusables (O->0, I/L->1) so a code typed with
+ * minor transcription variance still derives the same KEK.
+ */
+export function normalizeRecoveryCode(code: string): string {
+  return code
+    .toUpperCase()
+    .replace(/[\s-]+/g, '')
+    .replace(/O/g, '0')
+    .replace(/[IL]/g, '1');
+}
+
+/** Minimum normalized length (~80-bit base32 floor) accepted as a recovery-code anchor. */
+const MIN_RECOVERY_CODE_LENGTH = 16;
+
+/**
+ * Defense-in-depth guard so an integrating app cannot seal a recovery-code anchor
+ * from a weak, offline-brute-forceable string (e.g. a short PIN). `generateRecoveryCode`
+ * output is well above this floor.
+ */
+export function assertRecoveryCodeStrength(code: string): void {
+  if (normalizeRecoveryCode(code).length < MIN_RECOVERY_CODE_LENGTH) {
+    throw new Error(
+      `recovery-core: recovery code too short (min ${MIN_RECOVERY_CODE_LENGTH} chars after normalization)`,
+    );
+  }
+}

--- a/packages/recovery-core/src/recovery-code.test.ts
+++ b/packages/recovery-core/src/recovery-code.test.ts
@@ -1,0 +1,141 @@
+import { randomBytes } from './envelope.js';
+import { generateRecoveryCode, normalizeRecoveryCode, parseArgon2idParams } from './kdf.js';
+import { Recoverable } from './Recoverable.js';
+import type { Envelope, EnvelopeTransport, NativePrf } from './types.js';
+
+/** In-memory transport for the round-trip. */
+function memoryTransport(): EnvelopeTransport {
+  let stored: Envelope | null = null;
+  return {
+    put: async (_scopeKey, envelope) => {
+      stored = envelope;
+    },
+    get: async () => stored,
+  };
+}
+
+/** The code anchor never touches the authenticator; fail loud if it does. */
+const failNative = () => {
+  throw new Error('native should not be called for a code recipient');
+};
+const stubNative: NativePrf = {
+  capabilities: failNative,
+  register: failNative,
+  assert: failNative,
+};
+
+function makeRecoverable(transport: EnvelopeTransport): Recoverable {
+  return new Recoverable({ native: stubNative, transport, rpId: 'example.test' });
+}
+
+/** Seal a fresh secret under one or more code recipients at scope 'scope'. */
+async function sealCodes(
+  ...codes: string[]
+): Promise<{ recoverable: Recoverable; secret: Uint8Array }> {
+  const recoverable = makeRecoverable(memoryTransport());
+  const secret = randomBytes(32);
+  await recoverable.set('scope', secret, {
+    userId: 'u',
+    userName: 'n',
+    recipients: codes.map((code) => ({ kind: 'code', code })),
+  });
+  return { recoverable, secret };
+}
+
+describe('recovery code format', () => {
+  it('generates 7 dash-separated groups of 4 Crockford base32 symbols', () => {
+    const code = generateRecoveryCode();
+    expect(code).toMatch(/^[0-9ABCDEFGHJKMNPQRSTVWXYZ]{4}(-[0-9ABCDEFGHJKMNPQRSTVWXYZ]{4}){6}$/);
+  });
+
+  it('generates distinct codes', () => {
+    expect(generateRecoveryCode()).not.toEqual(generateRecoveryCode());
+  });
+
+  it('normalizes separators, case, and Crockford confusables', () => {
+    expect(normalizeRecoveryCode('k7qw-9f3m')).toBe('K7QW9F3M');
+    expect(normalizeRecoveryCode('O I L')).toBe('011');
+  });
+
+  it('can produce every Crockford symbol (uniformity smoke test)', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 300; i += 1) {
+      for (const ch of generateRecoveryCode().replace(/-/g, '')) {
+        seen.add(ch);
+      }
+    }
+    // Includes R,S,T,V,W,X,Y,Z, which the earlier rejection sampling under-represented.
+    for (const ch of '0123456789ABCDEFGHJKMNPQRSTVWXYZ') {
+      expect(seen.has(ch)).toBe(true);
+    }
+  });
+});
+
+describe('parseArgon2idParams', () => {
+  it('accepts valid params', () => {
+    expect(parseArgon2idParams({ m: 19456, t: 2, p: 1, v: 19 })).toEqual({
+      m: 19456,
+      t: 2,
+      p: 1,
+      v: 19,
+    });
+  });
+
+  it('rejects zero, negative, non-integer, and unsupported-version params', () => {
+    expect(() => parseArgon2idParams({ m: 0, t: 2, p: 1, v: 19 })).toThrow();
+    expect(() => parseArgon2idParams({ m: 19456, t: -1, p: 1, v: 19 })).toThrow();
+    expect(() => parseArgon2idParams({ m: 1.5, t: 2, p: 1, v: 19 })).toThrow();
+    expect(() => parseArgon2idParams({ m: 19456, t: 2, p: 1, v: 16 })).toThrow();
+    expect(() => parseArgon2idParams({ t: 2, p: 1, v: 19 })).toThrow();
+  });
+});
+
+describe('code recipient (Anchor 3) round-trip', () => {
+  it('recovers the secret with the correct code', async () => {
+    const code = generateRecoveryCode();
+    const { recoverable, secret } = await sealCodes(code);
+
+    expect(await recoverable.recoverViaCode('scope', code)).toEqual(secret);
+  });
+
+  it('accepts a code typed with different case / spacing (normalization)', async () => {
+    const code = generateRecoveryCode();
+    const { recoverable, secret } = await sealCodes(code);
+
+    const messy = ` ${code.toLowerCase().replace(/-/g, ' ')} `;
+    expect(await recoverable.recoverViaCode('scope', messy)).toEqual(secret);
+  });
+
+  it('recovers via a non-first code recipient', async () => {
+    const first = generateRecoveryCode();
+    const second = generateRecoveryCode();
+    const { recoverable, secret } = await sealCodes(first, second);
+
+    // The second code must still recover even though it is not the first recipient.
+    expect(await recoverable.recoverViaCode('scope', second)).toEqual(secret);
+  });
+
+  it('rejects sealing a too-short (weak) code', async () => {
+    await expect(sealCodes('1234')).rejects.toThrow(/too short/i);
+  });
+
+  it('rejects a wrong code', async () => {
+    const { recoverable } = await sealCodes(generateRecoveryCode());
+
+    await expect(recoverable.recoverViaCode('scope', generateRecoveryCode())).rejects.toThrow();
+  });
+
+  it('throws when the envelope has no code recipient', async () => {
+    const transport = memoryTransport();
+    await transport.put('scope', {
+      v: 1,
+      blob: 'x',
+      salt: 'y',
+      recipients: [{ kind: 'social', memberId: 'm', wrap: 'w' }],
+    });
+
+    await expect(makeRecoverable(transport).recoverViaCode('scope', 'CODE')).rejects.toThrow(
+      /no.*code/i,
+    );
+  });
+});

--- a/packages/recovery-core/src/types.ts
+++ b/packages/recovery-core/src/types.ts
@@ -69,7 +69,7 @@ export interface SocialRecipient {
   readonly wrap: string;
 }
 
-/** Optional last-resort recipient. Deferred in v1 (kind reserved in the format). */
+/** Last-resort recipient: KEK = HKDF(Argon2id(recovery code)). The universal backstop (Anchor 3). */
 export interface CodeRecipient {
   readonly kind: 'code';
   readonly kdf: 'argon2id';

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,6 +161,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@daflan/keyward-recovery-core@workspace:packages/recovery-core"
   dependencies:
+    hash-wasm: "npm:^4.12.0"
     tsup: "npm:^8.5.1"
     typescript: "npm:^6.0.2"
     vitest: "npm:^4.1.4"
@@ -1335,6 +1336,13 @@ __metadata:
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
+  languageName: node
+  linkType: hard
+
+"hash-wasm@npm:^4.12.0":
+  version: 4.12.0
+  resolution: "hash-wasm@npm:4.12.0"
+  checksum: 10c0/6cb95055319810b6f673de755289960683a9831807690795f0e8918b2fd7e6ae5b82a9dc47cbace171cf2814b412ef68c315a0ead0b4d96bd3e56a05e4bde136
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #44.

Implements the **recovery-code recipient (Anchor 3)** in `recovery-core`: the universal backstop where passkey-PRF is unavailable (no-GMS / de-googled / Huawei / old Android / iOS < 18.4) and no family member can re-seal.

## What
- **`kdf.ts`** (new): Argon2id IKM via **hash-wasm** (WASM inlined; the one KDF dependency beyond WebCrypto). `generateRecoveryCode` (Crockford base32, 140-bit, 7 groups of 4, uniform), `normalizeRecoveryCode`, `parseArgon2idParams` (integer + range bounded, version-pinned to 0x13), `assertRecoveryCodeStrength`.
- **`Recoverable`**: `buildRecipient` 'code' case wraps the Data Key under `HKDF-SHA256(Argon2id(normalize(code), envelope.salt, params))` with default params m=19456/t=2/p=1/v=19 stored on the recipient. New **`recoverViaCode(scopeKey, code)`** tries every code recipient (handles a re-issued code).
- **`recovery-capacitor`** facade re-exports `generateRecoveryCode` / `normalizeRecoveryCode` / `Argon2idParams` / `CodeRecipient`.

## Quality
High-effort `/code-review` (6 findings fixed: uniform code generation, try-all code recipients, bounded param validation + version pin, min-code-strength guard, batched CSPRNG) + `/simplify` (deriveCodeKek dedup, randomBytes reuse, regex grouping, test helpers). typecheck + lint clean; 16 tests green; core + facade build clean.

## Out of scope (follow-up KW-34, native)
iOS `@available` 18.0 -> 18.4 floor bump + `capabilities()` real-probe (both need on-device verification).

Backs the Fawa client enroll sub-slice (passkey + recovery code, >=2-anchor). Milestone KW-29 / #36.